### PR TITLE
Added support for Python 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 django
 djangorestframework
 sphinx
+six


### PR DESCRIPTION
Now tested to work under Python 3.4.2, with backward compatibility retained. For supporting both Python 2.7 & Python 3 sanely, tox and test coverage is needed.
