### PR TITLE
Make pagination field configurable

### DIFF
--- a/rest_assured/testcases.py
+++ b/rest_assured/testcases.py
@@ -69,6 +69,7 @@ class BaseRESTAPITestCase(APITestCase):
 
 
 class ListAPITestCaseMixin(object):
+    pagination_results_field = 'results'
 
     """Adds a list view test to the test case."""
 
@@ -114,7 +115,11 @@ class ListAPITestCaseMixin(object):
         response = self.get_list_response(**kwargs)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-        self.assertIn('results', response.data)
+        results = response.data
+        if self.pagination_results_field:
+            self.assertIn(self.pagination_results_field, response.data)
+            results = results[self.pagination_results_field]
+        self.assertTrue(len(results) >= 1)
 
         return response
 


### PR DESCRIPTION
Made the pagination "results" field configurable in `ListAPITestCaseMixin`.
Fixes #8 

Still needs:
1. Tests - the current tests pass, but I don't know how to easily test renamed result fields, or no fields at all. Need to create another viewset for this.
2. Documentation.

@ydaniv , can you review? If it's good I can try adding tests / docs.