### PR TITLE
Add support of nested values in created_data and updated_data

### DIFF
--- a/rest_assured/testcases.py
+++ b/rest_assured/testcases.py
@@ -216,7 +216,7 @@ class CreateAPITestCaseMixin(object):
     #: The name of the field in the response data for looking up the created object in DB.
     response_lookup_field = 'id'
     # set specific format for request data. Available values are multipart and json
-    format = 'json'
+    create_request_format = 'json'
 
     def get_create_data(self):
         """Return the data used for the create request.
@@ -247,7 +247,7 @@ class CreateAPITestCaseMixin(object):
         if data is None:
             data = self.get_create_data()
 
-        return self.client.post(self.get_create_url(), data or {}, format=self.format, **kwargs)
+        return self.client.post(self.get_create_url(), data or {}, format=self.create_request_format, **kwargs)
 
     def get_lookup_from_response(self, data):
         """Return value for looking up the created object in DB.
@@ -353,7 +353,7 @@ class UpdateAPITestCaseMixin(object):
     #: The name of the field in the response data for looking up the created object in DB.
     relationship_lookup_field = 'id'
     # set specific format for request data. Available values are multipart and json
-    format = 'json'
+    update_request_format = 'json'
 
     def get_update_url(self):
         """Return the update endpoint url.
@@ -387,7 +387,7 @@ class UpdateAPITestCaseMixin(object):
         if use_patch is None:
             use_patch = self.use_patch
 
-        kwargs['format'] = self.format
+        kwargs['format'] = self.update_request_format
 
         return self.client.patch(*args, **kwargs) if use_patch else self.client.put(*args, **kwargs)
 

--- a/rest_assured/testcases.py
+++ b/rest_assured/testcases.py
@@ -215,6 +215,8 @@ class CreateAPITestCaseMixin(object):
     create_data = None
     #: The name of the field in the response data for looking up the created object in DB.
     response_lookup_field = 'id'
+    # set specific format for request data. Available values are multipart and json
+    format = 'json'
 
     def get_create_data(self):
         """Return the data used for the create request.
@@ -245,7 +247,7 @@ class CreateAPITestCaseMixin(object):
         if data is None:
             data = self.get_create_data()
 
-        return self.client.post(self.get_create_url(), data or {}, **kwargs)
+        return self.client.post(self.get_create_url(), data or {}, format=self.format, **kwargs)
 
     def get_lookup_from_response(self, data):
         """Return value for looking up the created object in DB.
@@ -350,6 +352,8 @@ class UpdateAPITestCaseMixin(object):
     update_results = None
     #: The name of the field in the response data for looking up the created object in DB.
     relationship_lookup_field = 'id'
+    # set specific format for request data. Available values are multipart and json
+    format = 'json'
 
     def get_update_url(self):
         """Return the update endpoint url.
@@ -382,6 +386,8 @@ class UpdateAPITestCaseMixin(object):
 
         if use_patch is None:
             use_patch = self.use_patch
+
+        kwargs['format'] = self.format
 
         return self.client.patch(*args, **kwargs) if use_patch else self.client.put(*args, **kwargs)
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -62,6 +62,3 @@ class TestCreateTestCase(TestCase):
         assert isinstance(created, Stuff)
         assert response.data['name'] == created.name
         assert response.data['url']
-
-    def test_nested_create(self):
-        pass

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -10,7 +10,7 @@ class TestCreateTestCase(TestCase):
         class MockCreateTestCase(CreateAPITestCaseMixin, mocks.MockTestCase):
             base_name = kwargs.pop('base_name', 'stuff')
             factory_class = mocks.StuffFactory
-            create_data = {"name": "moar stuff"}
+            create_data = {"name": "moar stuff", "nested": {"key": "value"}}
 
         self.case_class = MockCreateTestCase
 
@@ -62,3 +62,6 @@ class TestCreateTestCase(TestCase):
         assert isinstance(created, Stuff)
         assert response.data['name'] == created.name
         assert response.data['url']
+
+    def test_nested_create(self):
+        pass


### PR DESCRIPTION
For now, following code: 

```
create_data = {'key': 'value', 'nested': [{'nested_key': 'nested_value'}]}
```

will be converted(in Django seriazlier which parse the data) to  

```
{'key': 'value', 'nested': ["{'nested_key': 'nested_value'}"]}
```

 To avoid it, `format='json'` add to client parameters.
