### PR TITLE
Fix Travis CI build for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
-python: 3.5
 
+dist: precise  # fix installing Python 3.3, 3.2
 sudo: false
 
 env:


### PR DESCRIPTION
The build currently fails because of missing Python 3.3 interpreter after Travis switched the default distribution (https://blog.travis-ci.com/2017-08-31-trusty-as-default-status).

Maybe a better alternative would be removing Python 3.3 from the test matrix.