### PR TITLE
Fix import module six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django
 djangorestframework
 sphinx
+six

--- a/rest_assured/testcases.py
+++ b/rest_assured/testcases.py
@@ -1,10 +1,10 @@
 from django.db.models import Manager
 from django.core.exceptions import ObjectDoesNotExist
-from django.utils import six
+import six
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
-from django.utils.six import text_type
+from six import text_type
 
 
 class BaseRESTAPITestCase(APITestCase):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='maggotfish@gmail.com',
     license='BSD',
     packages=find_packages(),
-    install_requires=["django>=1.6", "djangorestframework>=2.4.3"],
+    install_requires=["django>=1.6", "djangorestframework>=2.4.3", "six"],
     zip_safe=False,
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Fix import module six to support Django versions >= 3.0, because django.utils.six module was removed from django-3.0